### PR TITLE
build(package.json): Fix typo

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "scripts": {
     "test": "yarn lint",
-    "clear": "rm -r dist/*",
+    "clear": "rm -rf dist/*",
     "build": "yarn clear && babel --out-dir dist src",
     "lint": "eslint src/**",
     "dev": "next dev -p 8080",


### PR DESCRIPTION
Fixes a typo in the 'clear' script in the package.json preventing the
package from being published.