### PR TITLE
fix(TextField): resolve underline jumpiness

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "styled-material-components",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "coming soon",
   "main": "dist/index.js",
   "scripts": {

--- a/pages/text-fields.js
+++ b/pages/text-fields.js
@@ -10,75 +10,69 @@ class TextFieldPage extends PureComponent {
     controlledInputValue: '',
   };
 
-  handleChange = e => this.setState({ controlledInputValue: e.target.value })
+  handleChange = e => this.setState({ controlledInputValue: e.target.value });
 
   render() {
-    return (<MaterialThemeProvider theme={{ primary: '#03A9F4' }}>
-      <div
-        className={this.props.className}>
-        <h1>Text Fields</h1>
-        <h2>Simple Examples</h2>
-        <TextField
-          hintText={'autofocus'}
-          containerStyle={{ marginBottom: '20px' }}
-          autoFocus />
-        <TextField
-          hintText={'Hint Text'}
-          containerStyle={{ marginBottom: '20px' }} />
-        <TextField
-          defaultValue={'Default Value'}
-          containerStyle={{ marginBottom: '20px' }} />
-        <TextField
-          containerStyle={{ marginBottom: '20px' }}
-          floatingLabelText={'floating label'} />
-        <TextField
-          hintText={'with hint text'}
-          containerStyle={{ marginBottom: '20px' }}
-          floatingLabelText={'floating label'} />
-        <TextField
-          containerStyle={{ marginBottom: '20px' }}
-          helperText={'persistent helper text'}
-          helperTextPersistent />
-        <TextField
-          containerStyle={{ marginBottom: '20px' }}
-          helperText={'default helper text'} />
-        <TextField
-          hintText={'disabled'}
-          containerStyle={{ marginBottom: '20px' }}
-          disabled />
-        <TextField
-          hintText={'Controlled Input'}
-          containerStyle={{ marginBottom: '20px' }}
-          value={this.state.controlledInputValue}
-          onChange={this.handleChange} />
-        <TextField
-          hintText={'Full Width'}
-          containerStyle={{ marginBottom: '20px' }}
-          fullWidth />
-        <h2>Error Examples</h2>
-        <TextField
-          hintText={'Controlled error'}
-          errorText={'This error was passed in'}
-          error
-          containerStyle={{ marginBottom: '20px' }} />
-        <TextField
-          hintText={'with validation'}
-          helperText={'helper text and validation'}
-          validator={validateLength}
-          errorText={'This should be at least 8 chars'}
-          containerStyle={{ marginBottom: '30px' }} />
-        <TextField
-          floatingLabelText={'A required field'}
-          required
-          containerStyle={{ marginBottom: '20px' }} />
-        <TextField
-          prefix={'$'}
-          containerStyle={{ marginBottom: '20px' }} />
-        <TextField
-          suffix={'lb'}
-          containerStyle={{ marginBottom: '20px' }} />
-      </div>
-    </MaterialThemeProvider>);
+    return (
+      <MaterialThemeProvider theme={{ primary: '#03A9F4' }}>
+        <div className={this.props.className}>
+          <h1>Text Fields</h1>
+          <h2>Simple Examples</h2>
+          <TextField hintText={'autofocus'} containerStyle={{ marginBottom: '20px' }} autoFocus />
+          <TextField hintText={'Hint Text'} containerStyle={{ marginBottom: '20px' }} />
+          <TextField defaultValue={'Default Value'} containerStyle={{ marginBottom: '20px' }} />
+          <TextField
+            containerStyle={{ marginBottom: '20px' }}
+            floatingLabelText={'floating label'}
+          />
+          <TextField
+            hintText={'with hint text'}
+            containerStyle={{ marginBottom: '20px' }}
+            floatingLabelText={'floating label'}
+          />
+          <TextField
+            containerStyle={{ marginBottom: '20px' }}
+            helperText={'persistent helper text'}
+            helperTextPersistent
+          />
+          <TextField containerStyle={{ marginBottom: '20px' }} helperText={'default helper text'} />
+          <TextField hintText={'disabled'} containerStyle={{ marginBottom: '20px' }} disabled />
+          <TextField
+            hintText={'Controlled Input'}
+            containerStyle={{ marginBottom: '20px' }}
+            value={this.state.controlledInputValue}
+            onChange={this.handleChange}
+          />
+          <TextField
+            hintText={'Focus disabled'}
+            containerStyle={{ marginBottom: '20px' }}
+            focusDisabled
+          />
+          <TextField hintText={'Full Width'} containerStyle={{ marginBottom: '20px' }} fullWidth />
+          <h2>Error Examples</h2>
+          <TextField
+            hintText={'Controlled error'}
+            errorText={'This error was passed in'}
+            error
+            containerStyle={{ marginBottom: '20px' }}
+          />
+          <TextField
+            hintText={'with validation'}
+            helperText={'helper text and validation'}
+            validator={validateLength}
+            errorText={'This should be at least 8 chars'}
+            containerStyle={{ marginBottom: '30px' }}
+          />
+          <TextField
+            floatingLabelText={'A required field'}
+            required
+            containerStyle={{ marginBottom: '20px' }}
+          />
+          <TextField prefix={'$'} containerStyle={{ marginBottom: '20px' }} />
+          <TextField suffix={'lb'} containerStyle={{ marginBottom: '20px' }} />
+        </div>
+      </MaterialThemeProvider>
+    );
   }
 }
 

--- a/src/components/TextField.js
+++ b/src/components/TextField.js
@@ -8,7 +8,7 @@ class TextFieldComponent extends PureComponent {
     focus: false,
     error: this.props.error || false,
     hasBeenFocused: false,
-  }
+  };
 
   onChange = (e) => {
     this.props.onChange && this.props.onChange(e);
@@ -19,17 +19,17 @@ class TextFieldComponent extends PureComponent {
       text,
       error: this.props.error || isInvalid || isEmptyButRequired,
     });
-  }
+  };
 
   onFocus = (e) => {
     this.props.onFocus && this.props.onFocus(e);
     this.setState({ focus: true, hasBeenFocused: true });
-  }
+  };
 
   onBlur = (e) => {
     this.props.onBlur && this.props.onBlur(e);
     this.setState({ focus: false });
-  }
+  };
 
   render() {
     return (
@@ -38,7 +38,8 @@ class TextFieldComponent extends PureComponent {
         error={this.state.error}
         className={'smc-text-field-container'}
         fullWidth={this.props.fullWidth}
-        disabled={this.props.disabled} >
+        disabled={this.props.disabled}
+      >
         <Suffix>{this.props.suffix}</Suffix>
         <Prefix>{this.props.prefix}</Prefix>
         <FloatingLabel
@@ -46,10 +47,11 @@ class TextFieldComponent extends PureComponent {
           error={this.state.error}
           hasPrefix={!!this.props.prefix}
           focus={this.state.focus}
-          floatingLabelStyle={this.state.error
-            ? this.props.floatingLabelErrorStyle
-            : this.props.floatingLabelStyle}
-          floating={this.state.focus || this.props.hintText || this.state.text.length}>
+          floatingLabelStyle={
+            this.state.error ? this.props.floatingLabelErrorStyle : this.props.floatingLabelStyle
+          }
+          floating={this.state.focus || this.props.hintText || this.state.text.length}
+        >
           {`${this.props.floatingLabelText || ''}${this.props.required ? '*' : ''}`}
           {/* <RequiredStar
             hasBeenFocused={this.state.hasBeenFocused}
@@ -61,21 +63,26 @@ class TextFieldComponent extends PureComponent {
           hintTextStyle={this.props.hintTextStyle}
           hasPrefix={this.props.prefix}
           error={this.props.error || this.state.error}
-          display={!this.props.defaultValue
-            && !this.state.text.length && !this.props.value} >
+          display={!this.props.defaultValue && !this.state.text.length && !this.props.value}
+        >
           {this.props.hintText}
         </HintText>
-        {this.props.helperText && <HelperText
-          className={'smc-text-field-helper-text'}
-          helperTextStyle={this.props.helperTextStyle}
-          display={!this.state.error
-            && (this.props.helperTextPersistent ? true : this.state.focus)}>
-          {this.props.helperText}
-        </HelperText>}
+        {this.props.helperText && (
+          <HelperText
+            className={'smc-text-field-helper-text'}
+            helperTextStyle={this.props.helperTextStyle}
+            display={
+              !this.state.error && (this.props.helperTextPersistent ? true : this.state.focus)
+            }
+          >
+            {this.props.helperText}
+          </HelperText>
+        )}
         <ErrorText
           display={this.state.error}
           className={'smc-text-field-error-text'}
-          errorTextStyle={this.props.errorTextStyle} >
+          errorTextStyle={this.props.errorTextStyle}
+        >
           {this.props.errorText}
         </ErrorText>
         <UnderlineFocus
@@ -83,7 +90,8 @@ class TextFieldComponent extends PureComponent {
           className={'smc-text-field-underline-focus'}
           underlineFocusStyle={this.props.underlineFocusStyle}
           focus={this.state.focus}
-          error={this.state.error} />
+          error={this.state.error}
+        />
         <Input
           hasPrefix={!!this.props.prefix}
           hasSuffix={!!this.props.suffix}
@@ -95,21 +103,33 @@ class TextFieldComponent extends PureComponent {
           onChange={this.onChange}
           onFocus={this.onFocus}
           onBlur={this.onBlur}
-          className={'smc-text-field-input'} />
+          className={'smc-text-field-input'}
+        />
       </Container>
     );
   }
 }
 
-const primaryTextColor = css`${props => props.theme.textColors.primary}`;
-const secondaryTextColor = css`${props => props.theme.textColors.secondary}`;
-const hintTextColor = css`${props => props.theme.textColors.hint}`;
-const primary = css`${props => props.theme.primary}`;
-const error = css`${props => props.theme.textColors.error || '#d50000'}`;
+const primaryTextColor = css`
+  ${props => props.theme.textColors.primary};
+`;
+const secondaryTextColor = css`
+  ${props => props.theme.textColors.secondary};
+`;
+const hintTextColor = css`
+  ${props => props.theme.textColors.hint};
+`;
+const primary = css`
+  ${props => props.theme.primary};
+`;
+const error = css`
+  ${props => props.theme.textColors.error || '#d50000'};
+`;
 
 const fadeInOut = css`
-  transition: all 200ms;
-  opacity: ${props => +props.display}`;
+  transition: opacity 200ms;
+  opacity: ${props => +props.display};
+`;
 
 const placeBelow = css`
   position: absolute;
@@ -119,14 +139,14 @@ const placeBelow = css`
 `;
 
 const Container = styled.div`
-  width: ${props => props.fullWidth ? '100%' : '167px'};
+  width: ${props => (props.fullWidth ? '100%' : '167px')};
   font-size: 1em;
   line-height: 1.5em;
   position: relative;
   background-color: transparent;
   font-family: lato, sans-serif;
-  border-bottom: 0.5px ${props => props.disabled ? 'dotted' : 'solid'};
-  border-bottom-color: ${props => props.error ? error : hintTextColor};
+  border-bottom: 0.5px ${props => (props.disabled ? 'dotted' : 'solid')};
+  border-bottom-color: ${props => (props.error ? error : hintTextColor)};
   ${props => props.containerStyle};
 `;
 
@@ -148,6 +168,7 @@ const Suffix = styled.div`
   bottom: 0;
   right: 0;
   color: ${hintTextColor};
+  ${props => props.suffixStyle};
 `;
 
 const Prefix = styled.div`
@@ -155,29 +176,30 @@ const Prefix = styled.div`
   bottom: 0;
   left: 0;
   color: ${hintTextColor};
+  ${props => props.prefixStyle};
 `;
 
 const FloatingLabel = styled.div`
   position: absolute;
   transition: all 200ms;
-  bottom: ${props => props.floating ? '1.5em' : '0em'};
-  font-size: ${props => props.floating ? '0.75em' : '1em'};
+  bottom: ${props => (props.floating ? '1.5em' : '0em')};
+  font-size: ${props => (props.floating ? '0.75em' : '1em')};
   color: ${(props) => {
     if (props.error) return error;
     return props.focus && props.floating ? primary : secondaryTextColor;
   }};
   width: 100%;
-  left: ${props => props.hasPrefix ? '1em' : '0em'}
+  left: ${props => (props.hasPrefix ? '1em' : '0em')};
   ${props => props.floatingLabelStyle};
 `;
 
 const HintText = styled.div`
   position: absolute;
-  color: ${props => props.error ? error : hintTextColor};
-  ${fadeInOut};
+  color: ${props => (props.error ? error : hintTextColor)};
+  opacity: ${props => +props.display};
   bottom: 0px;
   width: 100%;
-  left: ${props => props.hasPrefix ? '1em' : '0em'}
+  left: ${props => (props.hasPrefix ? '1em' : '0em')};
   ${props => props.hintTextStyle};
 `;
 
@@ -199,7 +221,7 @@ const UnderlineFocus = styled.div`
   position: absolute;
   bottom: 0px;
   border-top: 1.5px solid;
-  border-top-color: ${props => props.error ? error : primary};
+  border-top-color: ${props => (props.error ? error : primary)};
   width: 0%;
   transition: width 200ms;
   ${props => props.focus && 'width: 100%'};
@@ -221,7 +243,7 @@ const Input = styled.input`
   font-size: inherit;
   line-height: inherit;
   font-family: inherit;
-  padding-left: ${props => props.hasPrefix ? '1em' : '0'}
+  padding-left: ${props => (props.hasPrefix ? '1em' : '0')};
   ${props => props.inputStyle};
 `;
 

--- a/src/components/TextField.js
+++ b/src/components/TextField.js
@@ -86,7 +86,7 @@ class TextFieldComponent extends PureComponent {
           {this.props.errorText}
         </ErrorText>
         <UnderlineFocus
-          disabled={this.props.disabled}
+          disabled={this.props.focusDisabled}
           className={'smc-text-field-underline-focus'}
           underlineFocusStyle={this.props.underlineFocusStyle}
           focus={this.state.focus}
@@ -224,7 +224,7 @@ const UnderlineFocus = styled.div`
   border-top-color: ${props => (props.error ? error : primary)};
   width: 0%;
   transition: width 200ms;
-  ${props => props.focus && 'width: 100%'};
+  ${props => props.focus && !props.disabled && 'width: 100%'};
   ${props => props.underlineFocusStyle};
 `;
 


### PR DESCRIPTION
Remove the animation from the Hint Text in order to fix jumpy underline thickness

Add a disableFocus feature that disables the focus underline. This will be useful when using a textfield as a search bar.

Also a fair number of cosmetic changes from Prettier.