### PR TITLE
Version bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "styled-material-components",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "description": "coming soon",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "styled-material-components",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "description": "coming soon",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
This has to be bumped by two versions because at one point a version 0.0.16 was published errantly and quickly redacted. Once published, the same version number can not be reused again, see here https://github.com/npm/npm/issues/9266 and here https://github.com/npm/npm/issues/8305