### PR TITLE
fix(withRipple export): Export from correct place

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,6 @@ export { default as Button } from './components/Button';
 export { default as TextField } from './components/TextField';
 export * from './components/Card';
 export * from './components/Tabs';
-export { default as withRipple } from './decorators/withRipple';
+export { default as withRipple } from './mixins/ripple';
 export { default as ThemeProvider } from './theme/ThemeProvider';
 export { default as defaultTheme } from './theme/defaultTheme';


### PR DESCRIPTION
Exports withRipple from the mixins folder instead of the nonexistent
decorators folder.