### PR TITLE
fix(Snackbar): Add class to Message

### DIFF
--- a/src/components/Snackbar.js
+++ b/src/components/Snackbar.js
@@ -67,7 +67,9 @@ class SnackbarComponent extends PureComponent {
         className={`${this.props.className} smc-snackbar-container`}
         open={this.props.open}
         animation={animation}>
-        <Message>{this.props.message || this.props.children}</Message>
+        <Message className="smc-snackbar-message">
+          {this.props.message || this.props.children}
+        </Message>
       </SnackbarWrapper>
     );
   }


### PR DESCRIPTION
Adds a classname to the snackbar message so it can have its styles
overriden.