### PR TITLE
feat(Checkbox): Add Checkbox

### DIFF
--- a/pages/checkboxes.js
+++ b/pages/checkboxes.js
@@ -1,0 +1,58 @@
+import React, { PureComponent } from 'react';
+import MaterialThemeProvider from '../src/theme/ThemeProvider';
+import Checkbox from '../src/components/Checkbox';
+import List from '../src/components/List/List';
+import ListItem from '../src/components/List/ListItem';
+import defaultTheme from '../src/theme/defaultTheme';
+
+class CheckboxesPage extends PureComponent {
+  state = {
+    checked: true,
+  };
+
+  handleChange = () => {
+    const checked = !this.state.checked;
+    this.setState({ checked });
+  };
+
+  render() {
+    const { checked } = this.state;
+    return (
+      <MaterialThemeProvider theme={defaultTheme}>
+        <List>
+          <h1 style={{ marginLeft: 25 }}>Checkboxes</h1>
+          <ListItem>
+            <Checkbox id="checkbox2" />
+            <label htmlFor="checkbox2">Accent (default)</label>
+          </ListItem>
+          <ListItem>
+            <Checkbox primary label="Click Me" id="checkbox1" />
+            <label htmlFor="checkbox1">Primary</label>
+          </ListItem>
+          <ListItem>
+            <Checkbox defaultChecked id="checkbox3" />
+            <label htmlFor="checkbox3">Defaults to Checked</label>
+          </ListItem>
+          <ListItem>
+            <Checkbox disabled id="checkbox4" />
+            <label htmlFor="checkbox4">Disabled</label>
+          </ListItem>
+          <ListItem>
+            <Checkbox checked disabled id="checkbox5" />
+            <label htmlFor="checkbox5">Checked and Disabled</label>
+          </ListItem>
+          <ListItem>
+            <Checkbox checked={checked} onChange={this.handleChange} id="checkbox6" />
+            <label htmlFor="checkbox6">Controlled Checkbox</label>
+          </ListItem>
+          <ListItem>
+            <Checkbox indeterminate id="checkbox7" />
+            <label htmlFor="checkbox7">Indeterminate Checkbox</label>
+          </ListItem>
+        </List>
+      </MaterialThemeProvider>
+    );
+  }
+}
+
+export default CheckboxesPage;

--- a/pages/index.js
+++ b/pages/index.js
@@ -20,6 +20,9 @@ const HomePage = ({ className }) => (
         <Link href="/cards"><a>Cards Page</a></Link>
       </ListItem>
       <ListItem>
+        <Link href="/checkboxes"><a>Checkboxes Page</a></Link>
+      </ListItem>
+      <ListItem>
         <Link href="/chips"><a>Chips Page</a></Link>
       </ListItem>
       <ListItem>

--- a/src/components/Checkbox.js
+++ b/src/components/Checkbox.js
@@ -1,0 +1,142 @@
+import React, { PureComponent } from 'react';
+import styled from 'styled-components';
+
+class Checkbox extends PureComponent {
+  state = {
+    checked: this.props.checked || this.props.defaultChecked || false,
+    indeterminate: this.props.indeterminate || false,
+  };
+
+  handleInputChange = (e) => {
+    const checked = e.target.checked;
+    this.setState({ indeterminate: false, checked });
+
+    if (this.props.onChange) {
+      this.props.onChange(e);
+    }
+  };
+
+  render() {
+    const { primary, disabled, checked: checkedProp, value, id } = this.props;
+    const { indeterminate } = this.state;
+    // determine if checkbox is controlled or uncontrolled
+    const checked = checkedProp !== undefined ? checkedProp : this.state.checked;
+
+    return (
+      <CheckboxContainer
+        className="smc-checkbox-container"
+        primary={primary}
+        disabled={disabled}
+        checked={checked}
+      >
+        <CheckboxBackground
+          className="smc-checkbox-background"
+          primary={primary}
+          checked={checked}
+          disabled={disabled}
+          indeterminate={indeterminate}
+        >
+          {indeterminate && <IndeterminateMark className="smc-checkbox-indeterminate-mark" />}
+          {checked && !indeterminate && <CheckMark className="smc-checkbox-check-mark" />}
+        </CheckboxBackground>
+        <Input
+          onChange={this.handleInputChange}
+          disabled={disabled}
+          checked={checked}
+          value={value}
+          id={id}
+        />
+      </CheckboxContainer>
+    );
+  }
+}
+
+const CheckboxContainer = styled.div`
+  display: inline-block;
+  position: relative;
+  padding: 11px;
+  width: 18px;
+  height: 18px;
+  vertical-align: middle;
+  cursor: ${props => !props.disabled && 'pointer'};
+  :hover::before {
+    opacity: 0.04;
+  }
+  ::before {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    border-radius: 50%;
+    background-color: ${(props) => {
+    if (props.disabled) return 'transparent';
+    else if (!props.checked) return props.theme.textColors.secondary;
+    else if (props.primary) return props.theme.primary;
+    return props.theme.accent;
+  }};
+    opacity: 0;
+    content: '';
+  }
+`;
+
+const CheckboxBackground = styled.div`
+  display: inline-flex;
+  position: absolute;
+  left: 11px;
+  top: 11px;
+  bottom: 11px;
+  right: 11px;
+  border: solid 2px
+    ${(props) => {
+    if (props.checked || props.indeterminate) return 'transparent';
+    else if (props.disabled) return props.theme.disabledCheckbox;
+    return props.theme.textColors.secondary;
+  }};
+  border-radius: 2px;
+  background-color: ${(props) => {
+    if (props.checked || props.indeterminate) {
+      if (props.disabled) return props.theme.disabledCheckbox;
+      else if (props.primary) return props.theme.primary;
+      return props.theme.accent;
+    }
+  }};
+  align-items: center;
+  justify-content: center;
+`;
+
+const Input = styled.input.attrs({
+  type: 'checkbox',
+  disabled: props => props.disabled,
+})`
+  position: absolute;
+  opacity: 0;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  cursor: inherit;
+  margin: 0;
+`;
+
+const CheckMarkSvg = styled.svg`
+  fill: none;
+  stroke: ${props => props.theme.white};
+  width: 100%;
+  height: 100%;
+  stroke-width: 3.12px;
+`;
+
+const CheckMark = () => (
+  <CheckMarkSvg viewBox="0 0 24 24">
+    <path d="M1.73,12.91 8.1,19.28 22.79,4.59" />,
+  </CheckMarkSvg>
+);
+
+const IndeterminateMark = styled.div`
+  height: 2px;
+  width: 14px;
+  background-color: ${props => props.theme.white};
+`;
+
+export default Checkbox;

--- a/src/theme/defaultTheme.js
+++ b/src/theme/defaultTheme.js
@@ -30,6 +30,7 @@ const defaultTheme = {
     icon: black.alpha(0.38).toString(),
   },
   slider: sliderTheme,
+  disabledCheckbox: black.alpha(0.26).toString(),
 };
 
 export default defaultTheme;


### PR DESCRIPTION
addresses https://github.com/ConciergeAuctions/styled-material-components/issues/32

Now Link: https://docs-lxkvxelsyq.now.sh/

Checkboxes can be controlled or uncontrolled.
Accepts the following props:
- primary: render in primary theme color
- accent: render in accent theme color (default behavior)
- defaultChecked
- checked: for controlled checkboxes
- disabled
- indeterminate
- onChange: for controlled checkboxes
- value

TODO:
 - animations (halp)
 - labels

