### PR TITLE
docs(authors/license): move to root

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,14 @@
+#Authors
+
+Brad Decker <brad.decker@merlinlabs.com>
+David Lee <david.lee@merlinlabs.com>
+Natalia Bernard <natalia.bernard@merlinlabs.com>
+Marta Johnson <marta.johnson@merlinlabs.com>
+Nathan Schwartz <nathan.schwartz@merlinlabs.com>
+Krista Goralczyk <krista.goralczyk@gmail.com>
+Daniel St.Clair <daniel.stclair@merlinlabs.com>
+Jean Page <jean.page@merlinlabs.com>
+Bennett Staley <bennett.staley@merlinlabs.com>
+Ari Frankel <ari.frankel@merlinlabs.com>
+Pete Givens <pgivens@gmail.com>
+Ashley Woodall <ashley.woodall@merlinlabs.com>

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,9 @@
+Copyright (c) 2017 Merlin Labs (Home Services of America)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+Source: http://opensource.org/licenses/MIT

--- a/package.json
+++ b/package.json
@@ -18,8 +18,7 @@
     "type": "git",
     "url": "git+https://github.com/ConciergeAuctions/styled-material-components.git"
   },
-  "author": "Brad Decker <bhdecker84@gmail.com>",
-  "license": "ISC",
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/ConciergeAuctions/styled-material-components/issues"
   },


### PR DESCRIPTION
Adds an AUTHORS file modeled after the one in Node (all contributors).
Adds a LICENSE (MIT)
