### PR TITLE
ci(yarn): remove unnecessary global installation of yarn in ci container that has yarn already

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,6 @@ jobs:
           keys:
             - styled-material-components-{{ .Branch }}-{{ checksum "yarn.lock" }}
             - styled-material-components-{{ checksum "yarn.lock" }}
-      - run: npm i -g yarn@latest 
       - run: yarn install
       - save_cache:
           key: styled-material-components-{{ .Branch }}-{{ checksum "yarn.lock" }}


### PR DESCRIPTION
At first I was going to suggest we change to the recommended yarn installer away from a global npm install, but then I saw that the [Node/carbon](https://github.com/nodejs/docker-node/blob/994f8286cb0efc92578902d5fd11182f63a59869/8/Dockerfile) comes with Yarn pre-installed, so there's no need to install yarn at all.