### PR TITLE
feat(AUTHORS): scripted AUTHORS

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,14 +1,12 @@
-#Authors
+# Authors orderd by date of first contribution 
 
-Brad Decker <brad.decker@merlinlabs.com>
-David Lee <david.lee@merlinlabs.com>
-Natalia Bernard <natalia.bernard@merlinlabs.com>
-Marta Johnson <marta.johnson@merlinlabs.com>
-Nathan Schwartz <nathan.schwartz@merlinlabs.com>
-Krista Goralczyk <krista.goralczyk@gmail.com>
-Daniel St.Clair <daniel.stclair@merlinlabs.com>
-Jean Page <jean.page@merlinlabs.com>
-Bennett Staley <bennett.staley@merlinlabs.com>
-Ari Frankel <ari.frankel@merlinlabs.com>
-Pete Givens <pgivens@gmail.com>
-Ashley Woodall <ashley.woodall@merlinlabs.com>
+
+ Brad Decker <bhdecker84@gmail.com>
+ iamdavid0091 <iamdavid0091@gmail.com>
+ Cecilia Cisneros <cmvrie@utexas.edu>
+ martahj <marta.hourigan.johnson@gmail.com>
+ Ari Frankel <ari.l.frankel@gmail.com>
+ kristajg <krista.goralczyk@gmail.com>
+ Taylor King <dekkofilms@gmail.com>
+ ashwoodall <ash.woodall@gmail.com>
+ Pete Givens <pgivens@gmail.com>

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "export": "next build && next export -o docs",
     "prepublish": "yarn test && yarn build",
     "now-build": "yarn export && cd docs && now",
-    "prepush": "yarn lint"
+    "prepush": "yarn lint",
+    "postcommit": "bash ./scripts/update-authors.sh"
   },
   "repository": {
     "type": "git",
@@ -38,11 +39,11 @@
     "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-export-extensions": "^6.22.0",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
-    "husky": "^0.14.3",
     "babel-preset-env": "^1.6.1",
     "babel-preset-react": "^6.24.1",
     "eslint": "^4.10.0",
     "eslint-config-concierge-auctions-react": "^0.0.7",
+    "husky": "^0.14.3",
     "next": "^4.1.4",
     "now": "^9.0.1",
     "react-dom": "^16.0.0"

--- a/scripts/seed-authors.sh
+++ b/scripts/seed-authors.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+main () {
+  local root="$(git rev-parse --show-toplevel)"
+
+  # reset the AUTHORS file
+  echo -e $"# Authors orderd by date of first contribution \n\n" > $root/AUTHORS
+
+  # get authors name <email> contribution date in order
+  # remove bracketed text such as '[user]'
+  # and contributions not associated with a git account (ending in .local)
+  # filter unique by email address
+  # sort by date of contribution again after deduping
+  # remove date of contribution
+  # output to AUTHORS file
+  git log --format='%ad %an <%ae>' --date="short" --reverse | sed -e 's/\[.*\]//' -e '/.local>$/c\' | rev | sort -k 1,1 -u | rev | sort -n -t"-" -k1 -k2 -k3 | sed -e 's/^[0-9\-]*//' >> $root/AUTHORS
+
+  exit 0
+}
+
+main

--- a/scripts/update-authors.sh
+++ b/scripts/update-authors.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+main () {
+  local root="$(git rev-parse --show-toplevel)"
+  local hook=$root/.git/hooks/post-commit
+
+  # Check if the author is already listed
+  if grep -m 1 "$GIT_AUTHOR_EMAIL" $root/AUTHORS; then
+    exit 0
+  else
+    echo "adding you to authors"
+    
+    # add current commiter to AUTHORS file
+    echo " $GIT_AUTHOR_NAME <$GIT_AUTHOR_EMAIL>" >> $root/AUTHORS;
+
+    # disable post-commit hook temporarily
+    # to avoid recursively calling post-commit
+    chmod -x $hook
+    # commit AUTHORS
+    git add $root/AUTHORS
+    git commit --amend --no-edit --no-verify --quiet
+
+    # re-enable post-commit for the next commit
+    chmod +x $hook
+    exit 0
+  fi
+}
+
+main


### PR DESCRIPTION
This introduces a postcommit hook that will automatically update the AUTHORS file.

This will:
- search the AUTHORS file for the email of the committer
- add a line with name <email> for that committer if they are not represented already

This also introduces a `seed-authors` script that will
- output authors by order of first contribution to the AUTHORS file
- filter out repeat entries (unique by email) and commits accidentally added before being associated with a git account