### PR TITLE
fix(inkbar): fix inkbar flash

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "styled-material-components",
-  "version": "0.0.32",
+  "version": "0.0.33",
   "description": "coming soon",
   "main": "dist/index.js",
   "scripts": {

--- a/src/components/Tabs/InkBar.js
+++ b/src/components/Tabs/InkBar.js
@@ -15,7 +15,7 @@ const InkBar = ({ numTabs, selectedIndex, tabWidth, inkbarColor }) => (
     className='smc-tab-bar-scroller'
     numTabs={numTabs}
     selectedIndex={selectedIndex}
-    tabWidth={tabWidth}
+    tabWidth={tabWidth || 0}
     inkbarColor={inkbarColor} />
 );
 


### PR DESCRIPTION
On load the inkbar flashes to 100% width before shrinking to the
correct width. This is because it passed a value of undefined for the
tabWidth prop. This commit defaults that value to 0 for the tab, so
that it will not display the inkbar until after the width has been
determined.

This is a link to a screen grab of what I'm talking aboutL https://gfycat.com/BlondPossibleAmericancreamdraft

This is a link to this build https://docs-etaviocnju.now.sh, but note that you would need to refresh the tabs page to see the impact of this change, which is not supported.