### PR TITLE
fix(Chip): remove font-family from chip Label

### DIFF
--- a/src/components/Chip.js
+++ b/src/components/Chip.js
@@ -35,12 +35,11 @@ const Avatar = styled.div`
   justify-content: center;
   align-items: center;
   border-radius: 50%;
-  ${typography('body')} 
+  ${typography('body')}
   font-size: 16px;
 `;
 
 const Label = styled.span`
-  font-family: 'Roboto';
   margin: 0 12px;
 `;
 


### PR DESCRIPTION
This was leftover from before we added the font-family to the defaultTheme, but it breaks if Roboto is not installed locally. 