### PR TITLE
fix(seed-authors): replace append with write

### DIFF
--- a/scripts/seed-authors.sh
+++ b/scripts/seed-authors.sh
@@ -13,7 +13,7 @@ main () {
   # sort by date of contribution again after deduping
   # remove date of contribution
   # output to AUTHORS file
-  git log --format='%ad %an <%ae>' --date="short" --reverse | sed -e 's/\[.*\]//' -e '/.local>$/c\' | rev | sort -k 1,1 -u | rev | sort -n -t"-" -k1 -k2 -k3 | sed -e 's/^[0-9\-]*//' >> $root/AUTHORS
+  git log --format='%ad %an <%ae>' --date="short" --reverse | sed -e 's/\[.*\]//' -e '/.local>$/c\' | rev | sort -k 1,1 -u | rev | sort -n -t"-" -k1 -k2 -k3 | sed -e 's/^[0-9\-]*//' > $root/AUTHORS
 
   exit 0
 }


### PR DESCRIPTION
This is a very tiny fix. This hasn't been an issue for us, but it could if we ever reseeded the AUTHORS file. 

This commit makes the following change: Do not append the authors to the file. Instead overwrite that file